### PR TITLE
Fixes #49

### DIFF
--- a/classes/MigrationColumnType.php
+++ b/classes/MigrationColumnType.php
@@ -116,7 +116,7 @@ class MigrationColumnType extends BaseModel
             // The datetime type maps to datetime and timestamp. Use the name 
             // guessing as the only possible solution.
 
-            if (in_array($columnName, ['created_at', 'updated_at', 'deleted_at'])) {
+            if (in_array($columnName, ['created_at', 'updated_at', 'deleted_at', 'published_at'])) {
                 return self::TYPE_TIMESTAMP;
             }
 


### PR DESCRIPTION
Fixes rainlab/builder-plugin#49 by adding `published_at` to the list of column names that should be mapped from `DoctrineType::DATETIME` to `TYPE_TIMESTAMP` instead of `TYPE_DATETIME`.