### PR TITLE
Add recordsPerPage config in the config_list.yaml

### DIFF
--- a/widgets/DefaultBehaviorDesignTimeProvider.php
+++ b/widgets/DefaultBehaviorDesignTimeProvider.php
@@ -130,6 +130,7 @@ class DefaultBehaviorDesignTimeProvider extends BehaviorDesignTimeProviderBase
             'noRecordsMessage' => 'backend::lang.list.no_records',
             'showSetup' => true,
             'showCheckboxes' => true,
+            'recordsPerPage' => 50,
             'toolbar' => [
                 'buttons' => 'list_toolbar',
                 'search' => [

--- a/widgets/DefaultBehaviorDesignTimeProvider.php
+++ b/widgets/DefaultBehaviorDesignTimeProvider.php
@@ -130,7 +130,7 @@ class DefaultBehaviorDesignTimeProvider extends BehaviorDesignTimeProviderBase
             'noRecordsMessage' => 'backend::lang.list.no_records',
             'showSetup' => true,
             'showCheckboxes' => true,
-            'recordsPerPage' => 50,
+            'recordsPerPage' => 20,
             'toolbar' => [
                 'buttons' => 'list_toolbar',
                 'search' => [


### PR DESCRIPTION
In a big table with many records we get out off memory and can't rander the page without a limit of records per page.