### PR TITLE
Behavior list property showSorting defaults to true

### DIFF
--- a/classes/StandardBehaviorsRegistry.php
+++ b/classes/StandardBehaviorsRegistry.php
@@ -260,7 +260,9 @@ class StandardBehaviorsRegistry
             'showSorting' => [
                 'title' => Lang::get('rainlab.builder::lang.controller.property_behavior_list_show_sorting'),
                 'type' => 'checkbox',
-                'ignoreIfEmpty' => true,
+                'ignoreIfEmpty' => false,
+                'default' => true,
+                'ignoreIfDefault' => true,
             ],
             'defaultSort' => [
                 'title' => Lang::get('rainlab.builder::lang.controller.property_behavior_list_default_sort'),


### PR DESCRIPTION
As per https://octobercms.com/docs/backend/lists#configuring-list, it can be ignored if true, but written if false.