### PR TITLE
Add support for passing properties between components

### DIFF
--- a/components/RecordDetails.php
+++ b/components/RecordDetails.php
@@ -12,25 +12,25 @@ class RecordDetails extends ComponentBase
      * @var \October\Rain\Database\Model
      */
     public $record = null;
-    
+
     /**
      * Message to display if the record is not found.
      * @var string
      */
     public $notFoundMessage;
-    
+
     /**
      * Model column to display on the details page.
      * @var string
      */
     public $displayColumn;
-    
+
     /**
      * Model column to use as a record identifier for fetching the record from the database.
      * @var string
      */
     public $modelKeyColumn;
-    
+
     /**
      * Identifier value to load the record from the database.
      * @var string
@@ -135,6 +135,12 @@ class RecordDetails extends ComponentBase
         $this->modelKeyColumn = $this->page['modelKeyColumn'] = $this->property('modelKeyColumn');
         $this->identifierValue = $this->page['identifierValue'] = $this->property('identifierValue');
 
+        if (strpos($this->property('identifierValue'), '::') > 0) {
+            list($componentAlias, $property) = explode('::', $this->property('identifierValue'));
+            $componentObj = $this->findComponentByName($componentAlias);
+            $this->identifierValue = $componentObj->record->attributes[$property];
+        }
+
         if (!strlen($this->displayColumn)) {
             throw new SystemException('The display column name is not set.');
         }
@@ -156,6 +162,7 @@ class RecordDetails extends ComponentBase
         }
 
         $model = new $modelClassName();
+
         return $model->where($this->modelKeyColumn, '=', $this->identifierValue)->first();
     }
 }

--- a/components/RecordList.php
+++ b/components/RecordList.php
@@ -274,6 +274,12 @@ class RecordList extends ComponentBase
         $scope = $this->getScopeName($model);
         $scopeValue = $this->property('scopeValue');
 
+        if (strpos($this->property('scopeValue'), '::') > 0) {
+            list($componentAlias, $property) = explode('::', $this->property('scopeValue'));
+            $componentObj = $this->findComponentByName($componentAlias);
+            $this->scopeValue = $componentObj->record->attributes[$property];
+        }
+
         if ($scope !== null) {
             $model = $model->$scope($scopeValue);
         }

--- a/components/RecordList.php
+++ b/components/RecordList.php
@@ -274,10 +274,10 @@ class RecordList extends ComponentBase
         $scope = $this->getScopeName($model);
         $scopeValue = $this->property('scopeValue');
 
-        if (strpos($this->property('scopeValue'), '::') > 0) {
-            list($componentAlias, $property) = explode('::', $this->property('scopeValue'));
+        if (strpos($scopeValue, '::') > 0) {
+            list($componentAlias, $property) = explode('::', $scopeValue);
             $componentObj = $this->findComponentByName($componentAlias);
-            $this->scopeValue = $componentObj->record->attributes[$property];
+            $scopeValue = $componentObj->record->attributes[$property];
         }
 
         if ($scope !== null) {

--- a/components/RecordList.php
+++ b/components/RecordList.php
@@ -274,13 +274,11 @@ class RecordList extends ComponentBase
         $scope = $this->getScopeName($model);
         $scopeValue = $this->property('scopeValue');
 
-        if (strpos($scopeValue, '::') > 0) {
-            list($componentAlias, $property) = explode('::', $scopeValue);
-            $componentObj = $this->findComponentByName($componentAlias);
-            $scopeValue = $componentObj->record->attributes[$property];
-        }
-
         if ($scope !== null) {
+            if (strpos($scopeValue, '::') > 0) {
+                list($componentAlias, $property) = explode('::', $scopeValue);
+                $componentObj = $this->findComponentByName($componentAlias);
+                $scopeValue = $componentObj->record->attributes[$property];
             $model = $model->$scope($scopeValue);
         }
 


### PR DESCRIPTION
You can now use the `componentAlias::property` syntax to pull properties from other components on...
- the `scopeValue` property of `Record list`.
- the `identifierValue` property of `Record details`.