### PR TITLE
[WIP] Add enum support

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -3,8 +3,10 @@
 use Event;
 use Backend;
 use System\Classes\PluginBase;
+use RainLab\Builder\Classes\EnumDbType;
 use RainLab\Builder\Classes\StandardControlsRegistry;
 use RainLab\Builder\Classes\StandardBehaviorsRegistry;
+use Doctrine\DBAL\Types\Type;
 
 class Plugin extends PluginBase
 {

--- a/classes/DatabaseTableModel.php
+++ b/classes/DatabaseTableModel.php
@@ -189,18 +189,18 @@ class DatabaseTableModel extends BaseModel
             if (!isset($column['values'])) {
                 continue;
             }
-            
+
             $values = @json_decode(trim($column['values']));
 
             if ($column['type'] !== 'enum') {
                 throw new ValidationException([
-                    'columns' => Lang::get('rainlab.builder::lang.database.error_values_no_enum', 
+                    'columns' => Lang::get('rainlab.builder::lang.database.error_values_no_enum',
                         ['column' => $column['name']]
                     )
                 ]);
             } else if ($values === false || !is_array($values)) {
                 throw new ValidationException([
-                    'columns' => Lang::get('rainlab.builder::lang.database.error_values_json_parse', 
+                    'columns' => Lang::get('rainlab.builder::lang.database.error_values_json_parse',
                         ['column' => $column['name']]
                     )
                 ]);
@@ -215,7 +215,7 @@ class DatabaseTableModel extends BaseModel
 
             if (Str::length($name) > 64) {
                 throw new ValidationException([
-                    'columns' => Lang::get('rainlab.builder::lang.database.error_column_name_too_long', 
+                    'columns' => Lang::get('rainlab.builder::lang.database.error_column_name_too_long',
                         ['column' => $name]
                     )
                 ]);
@@ -229,7 +229,7 @@ class DatabaseTableModel extends BaseModel
             foreach ($this->columns as $innerIndex=>$innerColumn) {
                 if ($innerIndex != $outerIndex && $innerColumn['name'] == $outerColumn['name']) {
                     throw new ValidationException([
-                        'columns' => Lang::get('rainlab.builder::lang.database.error_table_duplicate_column', 
+                        'columns' => Lang::get('rainlab.builder::lang.database.error_table_duplicate_column',
                             ['column' => $outerColumn['name']]
                         )
                     ]);
@@ -404,7 +404,7 @@ class DatabaseTableModel extends BaseModel
             ];
 
             if ($typeName === EnumDbType::TYPENAME) {
-                var_dump($platform->getColumnDeclarationSQL($columnName));exit;
+                // @TODO: How to parse enum values?
             }
 
             $this->columns[] = $item;

--- a/classes/DatabaseTableSchemaCreator.php
+++ b/classes/DatabaseTableSchemaCreator.php
@@ -51,6 +51,10 @@ class DatabaseTableSchemaCreator extends BaseModel
         $result['unsigned'] = !!$options['unsigned'];
         $result['notnull'] = !$options['allow_null'];
         $result['autoincrement'] = !!$options['auto_increment'];
+        
+        if (isset($options['values'])) {
+            $result['columnDefinition'] = $options['values'];
+        }
 
         $default = trim($options['default']);
 

--- a/classes/EnumDbType.php
+++ b/classes/EnumDbType.php
@@ -6,29 +6,32 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 /**
  * Enum column type.
  *
- * Currently this class is used as a placeholder. Enum columns
- * are not supported by the Builder table management UI.
- *
  * @package rainlab\builder
  * @author Alexey Bobkov, Samuel Georges
  */
 class EnumDbType extends Type
 {
-    const TYPENAME = 'EnumDbType'; 
+    const TYPENAME = 'EnumDbType';
+
+    protected $values = [];
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        // return the SQL used to create your column type. To create a portable column type, use the $platform.
+        $values = array_map(function($val) { return "'".$val."'"; }, $fieldDeclaration['columnDefinition']);
+        return "ENUM(".implode(", ", $values).")";
     }
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        // This is executed when the value is read from the database. Make your conversions here, optionally using the $platform.
+        return $value;
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
-        // This is executed when the value is written to the database. Make your conversions here, optionally using the $platform.
+        if (!in_array($value, $this->values)) {
+            throw new \InvalidArgumentException("Invalid '".$this->name."' value.");
+        }
+        return $value;
     }
 
     public function getName()

--- a/classes/MigrationColumnType.php
+++ b/classes/MigrationColumnType.php
@@ -42,6 +42,7 @@ class MigrationColumnType extends BaseModel
     const TYPE_BOOLEAN = 'boolean';
     const TYPE_DECIMAL = 'decimal';
     const TYPE_DOUBLE = 'double';
+    const TYPE_ENUM = 'enum';
 
     const REGEX_LENGTH_SINGLE = '/^([0-9]+)$/';
     const REGEX_LENGTH_DOUBLE = '/^([0-9]+)\,([0-9]+)$/';
@@ -78,7 +79,8 @@ class MigrationColumnType extends BaseModel
             self::TYPE_BINARY => DoctrineType::BLOB,
             self::TYPE_BOOLEAN => DoctrineType::BOOLEAN,
             self::TYPE_DECIMAL => DoctrineType::DECIMAL,
-            self::TYPE_DOUBLE => DoctrineType::FLOAT
+            self::TYPE_DOUBLE => DoctrineType::FLOAT,
+            self::TYPE_ENUM => EnumDbType::TYPENAME,
         ];
     }
 

--- a/classes/TableMigrationCodeGenerator.php
+++ b/classes/TableMigrationCodeGenerator.php
@@ -422,6 +422,11 @@ class TableMigrationCodeGenerator extends BaseModel
         $method = $this->applyMethodIncrements($method, $column);
 
         $lengthStr = $this->formatLengthParameters($column, $method);
+
+        if ($typeName === EnumDbType::TYPENAME) {
+            return sprintf('\t\t$table->%s(\'%s\', %s)', $method, $columnName, $column->getcolumnDefinition());
+        }
+
         return sprintf('\t\t$table->%s(\'%s\'%s)', $method, $columnName, $lengthStr);
     }
 

--- a/classes/databasetablemodel/fields.yaml
+++ b/classes/databasetablemodel/fields.yaml
@@ -53,6 +53,7 @@ tabs:
                         boolean: Boolean
                         decimal: Decimal
                         double: Double
+                        enum: Enum
                     validation: 
                         required: 
                             message: rainlab.builder::lang.database.column_type_required
@@ -62,6 +63,8 @@ tabs:
                         regex:
                             pattern: (^[0-9]+$)|(^[0-9]+,[0-9]+$)
                             message: rainlab.builder::lang.database.column_validation_length
+                values:
+                    title: rainlab.builder::lang.database.column_name_values
                 unsigned:
                     title: rainlab.builder::lang.database.column_name_unsigned
                     type: checkbox

--- a/lang/cs/lang.php
+++ b/lang/cs/lang.php
@@ -59,7 +59,6 @@ return [
         'btn_add_column' => 'Přidat sloupec',
         'btn_delete_column' => 'Smazat sloupec',
         'confirm_delete' => 'Opravdu chcete smazat tuto tabulku?',
-        'error_enum_not_supported' => 'Tabulka obsahuje sloupce s typem "enum" které Builder aktuálně nepodporuje.',
         'error_table_name_invalid_prefix' => "Název tabulky by měl začínat prefixem pluginu: ':prefix'.",
         'error_table_name_invalid_characters' => 'Formát názvu tabulky není správný, měl by obsahovat pouze písmena, číslice a nebo podtržítka. Název by měl začínat písmenem a neměl by obsahovat mezery.',
         'error_table_duplicate_column' => "Takový název sloupce již existuje: ':column'.",

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -49,6 +49,7 @@ return [
         'column_name_length' => 'Length',
         'column_validation_length' => 'The Length value should be integer or specified as precision and scale (10,2) for decimal columns. Spaces are not allowed in the length column.',
         'column_validation_title' => 'Only digits, lower-case Latin letters and underscores are allowed in column names',
+        'column_name_values' => 'Values',
         'column_name_unsigned' => 'Unsigned',
         'column_name_nullable' => 'Nullable',
         'column_auto_increment' => 'AUTOINCR',
@@ -62,7 +63,6 @@ return [
         'timestamps_exist' => 'created_at and deleted_at columns already exist in the table.',
         'soft_deleting_exist' => 'deleted_at column already exists in the table.',
         'confirm_delete' => 'Delete the table?',
-        'error_enum_not_supported' => 'The table contains column(s) with type "enum" which is not currently supported by the Builder.',
         'error_table_name_invalid_prefix' => "Table name should start with the plugin prefix: ':prefix'.",
         'error_table_name_invalid_characters' => 'Invalid table name. Table names should contain only Latin letters, digits and underscores. Names should start with a Latin letter and could not contain spaces.',
         'error_table_duplicate_column' => "Duplicate column name: ':column'.",
@@ -78,6 +78,8 @@ return [
         'error_unsigned_negative_value' => "The default value for the unsigned column ':column' can't be negative.",
         'error_table_already_exists' => "The table ':name' already exists in the database.",
         'error_table_name_too_long' => "The table name should not be longer than 64 characters.",
+        'error_values_json_parse' => "Failed to parse JSON array for column with name :column: ",
+        'error_values_no_enum' => "The column with name ':column' has non-empty values which is not allowed when it's not an enum type",
         'error_column_name_too_long' => "The column name ':column' is too long. Column names should not be longer than 64 characters."
     ],
     'model' => [

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -58,7 +58,6 @@ return [
         'btn_add_column' => 'Añadir columna',
         'btn_delete_column' => 'Borrar columna',
         'confirm_delete' => '¿Borrar la tabla?',
-        'error_enum_not_supported' => 'The table contains column(s) with type "enum" which is not currently supported by the Builder.',
         'error_table_name_invalid_prefix' => "Table name should start with the plugin prefix: ':prefix'.",
         'error_table_name_invalid_characters' => 'Invalid table name. Table names should contain only Latin letters, digits and underscores. Names should start with a Latin letter and could not contain spaces.',
         'error_table_duplicate_column' => "Duplicate column name: ':column'.",

--- a/lang/fa/lang.php
+++ b/lang/fa/lang.php
@@ -58,7 +58,6 @@ return [
         'btn_add_column' => 'افزودن ستون',
         'btn_delete_column' => 'حذف ستون',
         'confirm_delete' => 'آیا از حذف ان جدول اطمینان دارید؟',
-        'error_enum_not_supported' => 'جدول حاوی ستون(ها) ای با نوع enum می باشد که در حال حاظر توسط افزونه ساز پشتیبانی نمیشود.',
         'error_table_name_invalid_prefix' => 'نام جدول باید با پیشوند افزونه \':prefix\' آغاز شود. ',
         'error_table_name_invalid_characters' => 'نام جدول صحیح نمی باشد. نام جدول میتواند حاوی حروف لاتین، اعداد و خط زیر باشد و باید با حرف لاتین شروع شود. همچنین نام جدول نمیتواند شامل فاصله باشد.',
         'error_table_duplicate_column' => 'نام ستون \':column\' تکراری می باشد.',

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -57,7 +57,6 @@ return [
         'btn_add_column' => 'Kolom toevoegen',
         'btn_delete_column' => 'Kolom verwijderen',
         'confirm_delete' => 'Do you really want to delete the table?',
-        'error_enum_not_supported' => 'De tabel bevat kolom(men) van het type "enum", deze worden momenteel niet ondersteund door Builder.',
         'error_table_name_invalid_prefix' => "De tabelnaam moet starten met de plugin prefix: ':prefix'.",
         'error_table_name_invalid_characters' => 'Ongeldige tabelnaam. Tabelnamen mogen alleen latijnse letters, cijfers en underscores bevatten. Tabelnamen moeten beginnen met een letter en mogen geen spaties bevatten.',
         'error_table_duplicate_column' => "Kolomnaam bestaat reeds: ':column'.",


### PR DESCRIPTION
This pull request is not ready yet (work-in-progress) but I'd like to get some feedback before I proceed.

You can pick 'enum' from the type list and set the values in a new column called "values" which must be a JSON array. I'm sure this is not the best way but I'd like to get enums working first before implementing a fancy value picker like the one in creating options for a dropdown. Creating migrations and running them is already working but fetching the enum values from the table isn't working yet.

I'm not sure who to ask but @LukeTowers can you (or someone else) maybe take a look at this? I'm having issues with the following things:

1. How to get the enum values from the database? It looks like doctrine can't handle enums for all platforms. Maybe limit support for enums to only MySQL and parse the column definition by hand?
1. I created a new column called "values" after the "length" column. It's only being used by enums. Is this okay?

I'd like to get some feedback so I can continue working on this. Thanks in advance!