### PR TITLE
Fixed the issue that infinite loop-nested call ControlLibrary->getControlInfo()

### DIFF
--- a/classes/ControlLibrary.php
+++ b/classes/ControlLibrary.php
@@ -32,13 +32,13 @@ class ControlLibrary
             return $returnGrouped ? $this->groupedControls : $this->controls;
         }
 
-        Event::fire('pages.builder.registerControls', [$this]);
-
         $this->groupedControls = [
             $this->resolveControlGroupName(self::GROUP_STANDARD) => [],
             $this->resolveControlGroupName(self::GROUP_WIDGETS) => []
         ];
 
+        Event::fire('pages.builder.registerControls', [$this]);
+        
         foreach ($this->controls as $controlType=>$controlInfo) {
             $controlGroup = $this->resolveControlGroupName($controlInfo['group']);
 


### PR DESCRIPTION
When I try to extend the ControlLibrary by listen `pages.builder.registerControls`, I found I cannot call function `ControlLibrary->getControlInfo()` because it will result loop-nesrted call `ControlLibrary->getControlInfo()` again and again. 

After I researched the code of builder-plugin, I found the `Event::fire('pages.builder.registerControls', [$this]);` before `$this->groupedControls` has been initalized. Therefore I changed their order, and bug has been fixed.