### PR TITLE
Prevents generated from from auto-complete fields

### DIFF
--- a/classes/standardbehaviorsregistry/formcontroller/templates/create.htm.tpl
+++ b/classes/standardbehaviorsregistry/formcontroller/templates/create.htm.tpl
@@ -7,7 +7,7 @@
 
 <?php if (!$this->fatalError): ?>
 
-    <?= Form::open(['class' => 'layout']) ?>
+    <?= Form::open(['class' => 'layout', 'autocomplete' => 'off']) ?>
 
         <div class="layout-row">
             <?= $this->formRender() ?>


### PR DESCRIPTION
In some browsers form values stays filled after page refresh (checkbox are checked, for example) even if the model value differs