### PR TITLE
Update ControlLibrary.php

### DIFF
--- a/classes/ControlLibrary.php
+++ b/classes/ControlLibrary.php
@@ -299,11 +299,11 @@ class ControlLibrary
 
     protected function resolveControlGroupName($group)
     {
-        if ($group == self::GROUP_STANDARD) {
+        if ($group === self::GROUP_STANDARD) {
             return Lang::get('rainlab.builder::lang.form.control_group_standard');
         }
 
-        if ($group == self::GROUP_WIDGETS) {
+        if ($group === self::GROUP_WIDGETS) {
             return Lang::get('rainlab.builder::lang.form.control_group_widgets');
         }
 


### PR DESCRIPTION
The double equals (==) comparison in resolveControlGroupName() resolved any string to self::GROUP_STANDARD since PHP resolves strings to 0 when converted to an int. Changing to tripple equals (===) produces the expected functionality.