### PR TITLE
Add reserved keyword check for namespaces

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -6,6 +6,8 @@ use System\Classes\PluginBase;
 use System\Classes\CombineAssets;
 use RainLab\Builder\Classes\StandardControlsRegistry;
 use RainLab\Builder\Classes\StandardBehaviorsRegistry;
+use RainLab\Builder\Validation\ReservedValidator;
+use Illuminate\Support\Facades\Validator;
 
 class Plugin extends PluginBase
 {
@@ -126,6 +128,15 @@ class Plugin extends PluginBase
 
         Event::listen('pages.builder.registerControllerBehaviors', function($behaviorLibrary) {
             new StandardBehaviorsRegistry($behaviorLibrary);
+        });
+
+        // Register reserved keyword validation
+        Validator::resolver(function ($translator, $data, $rules, $messages, $customAttributes) {
+            $messages = [
+                'reserved' => e(trans('rainlab.builder::lang.validation.reserved'))
+            ];
+
+            return new ReservedValidator($translator, $data, $rules, $messages, $customAttributes);
         });
     }
 

--- a/classes/PluginBaseModel.php
+++ b/classes/PluginBaseModel.php
@@ -47,8 +47,8 @@ class PluginBaseModel extends PluginYamlModel
     protected $validationRules = [
         'name' => 'required',
         'author'   => ['required'],
-        'namespace'   => ['required', 'regex:/^[a-z]+[a-z0-9]+$/i'],
-        'author_namespace' => ['required', 'regex:/^[a-z]+[a-z0-9]+$/i'],
+        'namespace'   => ['required', 'regex:/^[a-z]+[a-z0-9]+$/i', 'reserved'],
+        'author_namespace' => ['required', 'regex:/^[a-z]+[a-z0-9]+$/i', 'reserved'],
         'homepage' => 'url'
     ];
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -678,4 +678,7 @@ return [
         'details_not_found_message_description' => 'Message to display if the record is not found. Used in the default component\'s partial.',
         'details_not_found_message_default' => 'Record not found',
     ],
+    'validation' => [
+        'reserved' => ':attribute cannot be a PHP reserved keyword'
+    ]
 ];

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,7 +1,6 @@
 <?php namespace RainLab\Builder\Models;
 
 use October\Rain\Database\Model;
-use Doctrine\DBAL\Platforms\Keywords\ReservedKeywordsValidator;
 use Rainlab\Builder\Rules\Reserved as ReservedRule;
 
 /**

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,6 +1,8 @@
 <?php namespace RainLab\Builder\Models;
 
 use October\Rain\Database\Model;
+use Doctrine\DBAL\Platforms\Keywords\ReservedKeywordsValidator;
+use Rainlab\Builder\Rules\Reserved as ReservedRule;
 
 /**
  * Builder settings model
@@ -24,6 +26,6 @@ class Settings extends Model
      */
     public $rules = [
         'author_name' => 'required',
-        'author_namespace' => ['required', 'regex:/^[a-z]+[a-z0-9]+$/i']
+        'author_namespace' => ['required', 'regex:/^[a-z]+[a-z0-9]+$/i', 'reserved']
     ];
 }

--- a/validation/ReservedValidator.php
+++ b/validation/ReservedValidator.php
@@ -1,0 +1,103 @@
+<?php namespace RainLab\Builder\Validation;
+
+use Illuminate\Validation\Validator;
+
+/**
+ * Reserved keyword validation.
+ *
+ * Validates for the use of any PHP-reserved keywords or constants, as specified from the PHP Manual
+ * here: http://php.net/manual/en/reserved.keywords.php
+ */
+class ReservedValidator extends Validator
+{
+    protected $reserved = [
+        '__class__',
+        '__dir__',
+        '__file__',
+        '__function__',
+        '__halt_compiler',
+        '__line__',
+        '__method__',
+        '__namespace__',
+        '__trait__',
+        'abstract',
+        'and',
+        'array',
+        'as',
+        'break',
+        'callable',
+        'case',
+        'catch',
+        'class',
+        'clone',
+        'const',
+        'continue',
+        'declare',
+        'default',
+        'die',
+        'do',
+        'echo',
+        'else',
+        'elseif',
+        'empty',
+        'enddeclare',
+        'endfor',
+        'endforeach',
+        'endif',
+        'endswitch',
+        'endwhile',
+        'eval',
+        'exit',
+        'extends',
+        'final',
+        'finally',
+        'for',
+        'foreach',
+        'function',
+        'global',
+        'goto',
+        'if',
+        'implements',
+        'include',
+        'include_once',
+        'instanceof',
+        'insteadof',
+        'interface',
+        'isset',
+        'list',
+        'namespace',
+        'new',
+        'or',
+        'print',
+        'private',
+        'protected',
+        'public',
+        'require',
+        'require_once',
+        'return',
+        'static',
+        'switch',
+        'throw',
+        'trait',
+        'try',
+        'unset',
+        'use',
+        'var',
+        'while',
+        'xor',
+        'yield'
+    ];
+
+    /**
+     * Reserved keyword validator.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateReserved($attribute, $value, $parameters)
+    {
+        return !in_array(strtolower($value), $this->reserved);
+    }
+}


### PR DESCRIPTION
Fixes issue #256.

I was not sure of where to put the validation messages, so it is currently in `Plugin.php` as part of the validator registration. Happy to take advice on where this may be better implemented.