### PR TITLE
Fix ReservedValidator (Re-PR without formatting code)

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -132,10 +132,6 @@ class Plugin extends PluginBase
 
         // Register reserved keyword validation
         Validator::resolver(function ($translator, $data, $rules, $messages, $customAttributes) {
-            $messages = [
-                'reserved' => e(trans('rainlab.builder::lang.validation.reserved'))
-            ];
-
             return new ReservedValidator($translator, $data, $rules, $messages, $customAttributes);
         });
     }

--- a/validation/ReservedValidator.php
+++ b/validation/ReservedValidator.php
@@ -124,6 +124,6 @@ class ReservedValidator extends Validator
      */
     public function replaceReserved($message, $attribute, $rule, $parameters)
     {
-        return str_replace(':attribute', $attribute, e(trans('rainlab.builder::lang.validation.reserved')));
+        return $this->replaceAttributePlaceholder(e(trans('rainlab.builder::lang.validation.reserved')), ucfirst($this->getDisplayableAttribute($attribute)));
     }
 }

--- a/validation/ReservedValidator.php
+++ b/validation/ReservedValidator.php
@@ -114,4 +114,16 @@ class ReservedValidator extends Validator
     {
         return !in_array(strtolower($value), $this->reserved);
     }
+
+    /**
+     * @param $message
+     * @param $attribute
+     * @param $rule
+     * @param $parameters
+     * @return mixed
+     */
+    public function replaceReserved($message, $attribute, $rule, $parameters)
+    {
+        return str_replace(':attribute', $attribute, e(trans('rainlab.builder::lang.validation.reserved')));
+    }
 }


### PR DESCRIPTION
Added the replaceReserved method to the ReservedValidator class.
This solves the problem with custom error messages.