### PR TITLE
Allow dynamic methods for the scope value in RecordList component

### DIFF
--- a/components/RecordList.php
+++ b/components/RecordList.php
@@ -206,7 +206,8 @@ class RecordList extends ComponentBase
             '-' => Lang::get('rainlab.builder::lang.components.list_scope_default')
         ];
         try {
-            $methods = get_class_methods($modelClass);
+            $model = new $modelClass;
+            $methods = $model->getClassMethods();
 
             foreach ($methods as $method) {
                 if (preg_match('/scope[A-Z].*/', $method)) {
@@ -295,7 +296,7 @@ class RecordList extends ComponentBase
             throw new SystemException('Invalid scope method name.');
         }
 
-        if (!method_exists($model, $scopeMethod)) {
+        if (!$model->methodExists($scopeMethod)) {
             throw new SystemException('Scope method not found.');
         }
 


### PR DESCRIPTION
Related Rain Library PR: https://github.com/octobercms/library/pull/375

Allows the scope value of a RecordList component instance to use a dynamic method added by an `addDynamicMethod` extension.

Fixes #270 