### PR TITLE
Added format as a supported property for the DatePicker widget

### DIFF
--- a/classes/StandardControlsRegistry.php
+++ b/classes/StandardControlsRegistry.php
@@ -685,6 +685,13 @@ class StandardControlsRegistry
                     ]
                 ],
                 'sortOrder' => 84
+            ],
+            'format' => [
+                'title' => Lang::get('rainlab.builder::lang.form.property_datepicker_format'),
+                'description' => Lang::get('rainlab.builder::lang.form.property_datepicker_year_format_description'),
+                'type' => 'string',
+                'ignoreIfEmpty' => true,
+                'sortOrder' => 85
             ]
         ];
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -214,7 +214,7 @@ return [
         'property_datepicker_year_range_description' => 'Number of years either side (eg 10) or array of upper/lower range (eg [1900,2015]). Leave empty for the default value (10).',
         'property_datepicker_year_range_invalid_format' => 'Invalid year range format. Use number (eg "10") or array of upper/lower range (eg "[1900,2015]")',
         'property_datepicker_format' => 'Format',
-        'property_datepicker_year_format_description' => 'Setup custom format date. Default format is YYYY-MM-DD',
+        'property_datepicker_year_format_description' => 'Define a custom date format. The default format is "Y-m-d"',
         'property_markdown_mode' => 'Mode',
         'property_markdown_mode_split' => 'Split',
         'property_markdown_mode_tab' => 'Tab',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -213,6 +213,8 @@ return [
         'property_datepicker_year_range' => 'Year range',
         'property_datepicker_year_range_description' => 'Number of years either side (eg 10) or array of upper/lower range (eg [1900,2015]). Leave empty for the default value (10).',
         'property_datepicker_year_range_invalid_format' => 'Invalid year range format. Use number (eg "10") or array of upper/lower range (eg "[1900,2015]")',
+        'property_datepicker_format' => 'Format',
+        'property_datepicker_year_format_description' => 'Setup custom format date. Default format is YYYY-MM-DD',
         'property_markdown_mode' => 'Mode',
         'property_markdown_mode_split' => 'Split',
         'property_markdown_mode_tab' => 'Tab',


### PR DESCRIPTION
Builder plugin didn't have ability to set up format and it rewrote fields.yaml
I verified on the project this new opputunity and it works.
Also, i added some strings only to english language directory. 
#287