### PR TITLE
Allow special default values for certain columns

### DIFF
--- a/classes/DatabaseTableModel.php
+++ b/classes/DatabaseTableModel.php
@@ -385,8 +385,12 @@ class DatabaseTableModel extends BaseModel
             ];
 
             // Format quoted "null" values with quotes
-            if ($column->getNotnull() === false && strtolower($item['default']) === 'null') {
-                $item['default'] = sprintf("'%s'", $item['default']);
+            if ($column->getNotnull() === false) {
+                if ($item['default'] === null) {
+                    $item['default'] = 'null';
+                } elseif (strtolower($item['default']) === 'null') {
+                    $item['default'] = "'null'";
+                }
             }
 
             $this->columns[] = $item;

--- a/classes/DatabaseTableModel.php
+++ b/classes/DatabaseTableModel.php
@@ -297,6 +297,10 @@ class DatabaseTableModel extends BaseModel
             if (!strlen($column['default'])) {
                 continue;
             }
+            // Allow null value for all nullable columns
+            if (strtolower($column['default']) === 'null' && (bool) $column['allow_null'] === true) {
+                continue;
+            }
 
             $default = trim($column['default']);
 

--- a/classes/DatabaseTableModel.php
+++ b/classes/DatabaseTableModel.php
@@ -57,7 +57,7 @@ class DatabaseTableModel extends BaseModel
 
         $tables = self::getSchemaManager()->listTableNames();
 
-        return array_filter($tables, function($item) use($prefix) {
+        return array_filter($tables, function ($item) use ($prefix) {
             return Str::startsWith($item, $prefix);
         });
     }
@@ -104,7 +104,7 @@ class DatabaseTableModel extends BaseModel
             'name.max' => Lang::get('rainlab.builder::lang.database.error_table_name_too_long')
         ];
 
-        Validator::extend('tablePrefix', function($attribute, $value, $parameters) use ($prefix) {
+        Validator::extend('tablePrefix', function ($attribute, $value, $parameters) use ($prefix) {
             $value = trim($value);
 
             if (!Str::startsWith($value, $prefix)) {
@@ -114,7 +114,7 @@ class DatabaseTableModel extends BaseModel
             return true;
         });
 
-        Validator::extend('uniqueTableName', function($attribute, $value, $parameters) {
+        Validator::extend('uniqueTableName', function ($attribute, $value, $parameters) {
             $value = trim($value);
 
             $schema = $this->getSchema();
@@ -189,7 +189,8 @@ class DatabaseTableModel extends BaseModel
 
             if (Str::length($name) > 64) {
                 throw new ValidationException([
-                    'columns' => Lang::get('rainlab.builder::lang.database.error_column_name_too_long', 
+                    'columns' => Lang::get(
+                        'rainlab.builder::lang.database.error_column_name_too_long',
                         ['column' => $name]
                     )
                 ]);
@@ -199,11 +200,12 @@ class DatabaseTableModel extends BaseModel
 
     protected function validateDuplicateColumns()
     {
-        foreach ($this->columns as $outerIndex=>$outerColumn) {
-            foreach ($this->columns as $innerIndex=>$innerColumn) {
+        foreach ($this->columns as $outerIndex => $outerColumn) {
+            foreach ($this->columns as $innerIndex => $innerColumn) {
                 if ($innerIndex != $outerIndex && $innerColumn['name'] == $outerColumn['name']) {
                     throw new ValidationException([
-                        'columns' => Lang::get('rainlab.builder::lang.database.error_table_duplicate_column', 
+                        'columns' => Lang::get(
+                            'rainlab.builder::lang.database.error_table_duplicate_column',
                             ['column' => $outerColumn['name']]
                         )
                     ]);
@@ -281,8 +283,7 @@ class DatabaseTableModel extends BaseModel
         foreach ($this->columns as $column) {
             try {
                 MigrationColumnType::validateLength($column['type'], $column['length']);
-            }
-            catch (Exception $ex) {
+            } catch (Exception $ex) {
                 throw new ValidationException([
                     'columns' => $ex->getMessage()
                 ]);
@@ -326,7 +327,7 @@ class DatabaseTableModel extends BaseModel
             }
 
             if ($column['type'] == MigrationColumnType::TYPE_BOOLEAN) {
-                if (!preg_match('/^0|1$/', $default)) {
+                if (!preg_match('/^0|1|true|false$/i', $default)) {
                     throw new ValidationException([
                         'columns' => Lang::get('rainlab.builder::lang.database.error_boolean_default_value', ['column'=>$column['name']])
                     ]);
@@ -382,6 +383,11 @@ class DatabaseTableModel extends BaseModel
                 'default' => $column->getDefault(),
                 'id' => $columnName,
             ];
+
+            // Format quoted "null" values with quotes
+            if ($column->getNotnull() === false && strtolower($item['default'] === 'null')) {
+                $item['default'] = sprintf("'%s'", $item['default']);
+            }
 
             $this->columns[] = $item;
         }

--- a/classes/DatabaseTableModel.php
+++ b/classes/DatabaseTableModel.php
@@ -385,7 +385,7 @@ class DatabaseTableModel extends BaseModel
             ];
 
             // Format quoted "null" values with quotes
-            if ($column->getNotnull() === false && strtolower($item['default'] === 'null')) {
+            if ($column->getNotnull() === false && strtolower($item['default']) === 'null') {
                 $item['default'] = sprintf("'%s'", $item['default']);
             }
 

--- a/classes/DatabaseTableSchemaCreator.php
+++ b/classes/DatabaseTableSchemaCreator.php
@@ -54,11 +54,21 @@ class DatabaseTableSchemaCreator extends BaseModel
 
         $default = trim($options['default']);
 
-        // Note - this code doesn't allow to set empty string as default. 
+        // Note - this code doesn't allow to set empty string as default.
         // But converting empty strings to NULLs is required for the further
         // work with Doctrine types. As an option - empty strings could be specified
         // as '' in the editor UI (table column editor).
-        $result['default'] = $default === '' ? null : $default;
+        if ($result['notnull'] === false) {
+            if (strtolower($default) === 'null') {
+                $result['default'] = null;
+            } elseif (preg_match('/^[\'"]null[\'"]$/i', $default)) {
+                $result['default'] = 'null';
+            } else {
+                $result['default'] = $default === '' ? null : $default;
+            }
+        } else {
+            $result['default'] = $default === '' ? null : $default;
+        }
 
         return $result;
     }

--- a/classes/TableMigrationCodeGenerator.php
+++ b/classes/TableMigrationCodeGenerator.php
@@ -26,8 +26,8 @@ class TableMigrationCodeGenerator extends BaseModel
      * Generates code for creating or updating a database table.
      * @param \Doctrine\DBAL\Schema\Table $updatedTable Specifies the updated table schema.
      * @param \Doctrine\DBAL\Schema\Table $existingTable Specifies the existing table schema, if applicable.
-     * @param string $newTableName An updated name of the theme. 
-     * @return string|boolean Returns the migration up() and down() methods code. 
+     * @param string $newTableName An updated name of the theme.
+     * @return string|boolean Returns the migration up() and down() methods code.
      * Returns false if there the table was not changed.
      */
     public function createOrUpdateTable($updatedTable, $existingTable, $newTableName)
@@ -48,8 +48,7 @@ class TableMigrationCodeGenerator extends BaseModel
 
                 $tableDiff->newName = $newTableName;
             }
-        }
-        else {
+        } else {
             /*
              * The table doesn't exist
              */
@@ -99,7 +98,7 @@ class TableMigrationCodeGenerator extends BaseModel
     /**
      * Generates code for dropping a database table.
      * @param \Doctrine\DBAL\Schema\Table $existingTable Specifies the existing table schema.
-     * @return string Returns the migration up() and down() methods code. 
+     * @return string Returns the migration up() and down() methods code.
      */
     public function dropTable($existingTable)
     {
@@ -113,7 +112,7 @@ class TableMigrationCodeGenerator extends BaseModel
     {
         /*
          * Although it might seem that a reverse diff could be used
-         * for the down() method, that's not so. The up and down operations 
+         * for the down() method, that's not so. The up and down operations
          * are not fully symmetrical.
          */
 
@@ -171,16 +170,16 @@ class TableMigrationCodeGenerator extends BaseModel
             $result .= $this->generateColumnCode($columnDiff, self::COLUMN_MODE_CHANGE);
         }
 
-        foreach ($tableDiff->renamedColumns as $oldName=>$column) {
+        foreach ($tableDiff->renamedColumns as $oldName => $column) {
             $result .= $this->generateColumnRenameCode($oldName, $column->getName());
         }
 
-        foreach ($tableDiff->removedColumns as $name=>$column) {
+        foreach ($tableDiff->removedColumns as $name => $column) {
             $result .= $this->generateColumnRemoveCode($name);
         }
 
         $primaryKey = $changedPrimaryKey ?
-            $this->findPrimaryKeyIndex($tableDiff->changedIndexes, $newOrUpdatedTable) : 
+            $this->findPrimaryKeyIndex($tableDiff->changedIndexes, $newOrUpdatedTable) :
             $this->findPrimaryKeyIndex($tableDiff->addedIndexes, $newOrUpdatedTable);
 
         if ($primaryKey) {
@@ -198,8 +197,7 @@ class TableMigrationCodeGenerator extends BaseModel
 
         if ($isNewTable) {
             $result = $this->generateTableDropCode($tableDiff->name);
-        }
-        else {
+        } else {
             $changedPrimaryKey = $this->getChangedOrRemovedPrimaryKey($tableDiff);
             $addedPrimaryKey = $this->findPrimaryKeyIndex($tableDiff->addedIndexes, $newOrUpdatedTable);
 
@@ -232,11 +230,11 @@ class TableMigrationCodeGenerator extends BaseModel
                     $result .= $this->generateColumnCode($columnDiff, self::COLUMN_MODE_REVERT);
                 }
 
-                foreach ($tableDiff->renamedColumns as $oldName=>$column) {
+                foreach ($tableDiff->renamedColumns as $oldName => $column) {
                     $result .= $this->generateColumnRenameCode($column->getName(), $oldName);
                 }
 
-                foreach ($tableDiff->removedColumns as $name=>$column) {
+                foreach ($tableDiff->removedColumns as $name => $column) {
                     $result .= $this->generateColumnCode($column, self::COLUMN_MODE_CREATE);
                 }
 
@@ -361,22 +359,22 @@ class TableMigrationCodeGenerator extends BaseModel
         $forceFlagsChange = false;
 
         switch ($mode) {
-            case self::COLUMN_MODE_CREATE: 
+            case self::COLUMN_MODE_CREATE:
                 $column = $columnData;
                 $changeMode = false;
-            break;
-            case self::COLUMN_MODE_CHANGE: 
+                break;
+            case self::COLUMN_MODE_CHANGE:
                 $column = $columnData->column;
                 $changeMode = true;
 
                 $forceFlagsChange = in_array('type', $columnData->changedProperties);
-            break;
-            case self::COLUMN_MODE_REVERT: 
+                break;
+            case self::COLUMN_MODE_REVERT:
                 $column = $columnData->fromColumn;
                 $changeMode = true;
 
                 $forceFlagsChange = in_array('type', $columnData->changedProperties);
-            break;
+                break;
         }
 
         $result = $this->generateColumnMethodCall($column);
@@ -433,8 +431,7 @@ class TableMigrationCodeGenerator extends BaseModel
             if (!$column->getNotnull()) {
                 $result = $this->generateBooleanMethod('nullable', true);
             }
-        }
-        elseif (in_array('notnull', $columnData->changedProperties) || $forceFlagsChange) {
+        } elseif (in_array('notnull', $columnData->changedProperties) || $forceFlagsChange) {
             $result = $this->generateBooleanMethod('nullable', !$column->getNotnull());
         }
 
@@ -449,8 +446,7 @@ class TableMigrationCodeGenerator extends BaseModel
             if ($column->getUnsigned()) {
                 $result = $this->generateBooleanMethod('unsigned', true);
             }
-        }
-        elseif (in_array('unsigned', $columnData->changedProperties) || $forceFlagsChange) {
+        } elseif (in_array('unsigned', $columnData->changedProperties) || $forceFlagsChange) {
             $result = $this->generateBooleanMethod('unsigned', $column->getUnsigned());
         }
 
@@ -470,12 +466,10 @@ class TableMigrationCodeGenerator extends BaseModel
             if (strlen($default)) {
                 $result = $this->generateDefaultMethodCall($default, $column);
             }
-        }
-        elseif (in_array('default', $columnData->changedProperties) || $forceFlagsChange) {
+        } elseif (in_array('default', $columnData->changedProperties) || $forceFlagsChange) {
             if (strlen($default)) {
                 $result = $this->generateDefaultMethodCall($default, $column);
-            }
-            elseif ($changeMode) {
+            } elseif ($changeMode) {
                 $result = sprintf('->default(null)');
             }
         }
@@ -490,10 +484,19 @@ class TableMigrationCodeGenerator extends BaseModel
 
         $type = MigrationColumnType::toMigrationMethodName($typeName, $columnName);
 
-        if (in_array($type, MigrationColumnType::getIntegerTypes()) || 
+        if (in_array($type, MigrationColumnType::getIntegerTypes()) ||
             in_array($type, MigrationColumnType::getDecimalTypes()) ||
             $type == MigrationColumnType::TYPE_BOOLEAN) {
             return sprintf('->default(%s)', $default);
+        }
+
+        // Allow `null` value for nullable columns
+        if ($column->getNotnull() === false) {
+            if (strtolower($default) === 'null' && $column->getNotnull() === false) {
+                return '->default(null)';
+            } elseif (preg_match('/^[\'"]null[\'"]$/i', $default)) {
+                return '->default(\'null\')';
+            }
         }
 
         return sprintf('->default(\'%s\')', $this->quoteParameter($default));
@@ -548,9 +551,9 @@ class TableMigrationCodeGenerator extends BaseModel
 
     protected function tableHasNameOrColumnChanges($tableDiff, $columnChangesOnly = false)
     {
-        $result = $tableDiff->addedColumns 
-                || $tableDiff->changedColumns 
-                || $tableDiff->removedColumns 
+        $result = $tableDiff->addedColumns
+                || $tableDiff->changedColumns
+                || $tableDiff->removedColumns
                 || $tableDiff->renamedColumns;
 
         if ($columnChangesOnly) {
@@ -562,7 +565,7 @@ class TableMigrationCodeGenerator extends BaseModel
 
     protected function tableHasPrimaryKeyChanges($tableDiff)
     {
-        return $this->findPrimaryKeyIndex($tableDiff->addedIndexes, $tableDiff->fromTable) || 
+        return $this->findPrimaryKeyIndex($tableDiff->addedIndexes, $tableDiff->fromTable) ||
                 $this->findPrimaryKeyIndex($tableDiff->changedIndexes, $tableDiff->fromTable) ||
                 $this->findPrimaryKeyIndex($tableDiff->removedIndexes, $tableDiff->fromTable);
     }

--- a/classes/TableMigrationCodeGenerator.php
+++ b/classes/TableMigrationCodeGenerator.php
@@ -490,15 +490,6 @@ class TableMigrationCodeGenerator extends BaseModel
             return sprintf('->default(%s)', $default);
         }
 
-        // Allow `null` value for nullable columns
-        if ($column->getNotnull() === false) {
-            if (strtolower($default) === 'null') {
-                return '->default(null)';
-            } elseif (preg_match('/^[\'"]null[\'"]$/i', $default)) {
-                return '->default(\'null\')';
-            }
-        }
-
         return sprintf('->default(\'%s\')', $this->quoteParameter($default));
     }
 

--- a/classes/TableMigrationCodeGenerator.php
+++ b/classes/TableMigrationCodeGenerator.php
@@ -492,7 +492,7 @@ class TableMigrationCodeGenerator extends BaseModel
 
         // Allow `null` value for nullable columns
         if ($column->getNotnull() === false) {
-            if (strtolower($default) === 'null' && $column->getNotnull() === false) {
+            if (strtolower($default) === 'null') {
                 return '->default(null)';
             } elseif (preg_match('/^[\'"]null[\'"]$/i', $default)) {
                 return '->default(\'null\')';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -74,7 +74,7 @@ return [
         'error_unsigned_type_not_int' => "Error in the ':column' column. The Unsigned flag can be applied only to integer type columns.",
         'error_integer_default_value' => "Invalid default value for the integer column ':column'. The allowed formats are '10', '-10'.",
         'error_decimal_default_value' => "Invalid default value for the decimal or double column ':column'. The allowed formats are '1.00', '-1.00'.",
-        'error_boolean_default_value' => "Invalid default value for the boolean column ':column'. The allowed values are '0' and '1'.",
+        'error_boolean_default_value' => "Invalid default value for the boolean column ':column'. The allowed values are '0' and '1', or 'true' and 'false'.",
         'error_unsigned_negative_value' => "The default value for the unsigned column ':column' can't be negative.",
         'error_table_already_exists' => "The table ':name' already exists in the database.",
         'error_table_name_too_long' => "The table name should not be longer than 64 characters.",


### PR DESCRIPTION
- If column is nullable, allow `null` for a NULL value, and `"null"` as a string "null"
- If column is a boolean, allow `true` and `false` as values.

Fixes #280.