### PR TITLE
Ability to order versions list descending

### DIFF
--- a/assets/less/builder.less
+++ b/assets/less/builder.less
@@ -196,7 +196,3 @@ div.control-table .toolbar a.builder-custom-table-button {
         }
     }
 }
-
-.sidepanel-content-header a.white {
-    color: #fff;
-}

--- a/assets/less/builder.less
+++ b/assets/less/builder.less
@@ -196,3 +196,7 @@ div.control-table .toolbar a.builder-custom-table-button {
         }
     }
 }
+
+.sidepanel-content-header a.white {
+    color: #fff;
+}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -548,6 +548,8 @@ return [
         'hint_apply' => 'Applying a version will also apply all older unapplied versions of the plugin.',
         'dont_show_again' => 'Don\'t show again',
         'save_unapplied_version' => 'Save unapplied version',
+        'sort_ascending' => 'Sort ascending',
+        'sort_descending' => 'Sort descending',
     ],
     'menu' => [
         'menu_label' => 'Backend Menu',

--- a/widgets/VersionList.php
+++ b/widgets/VersionList.php
@@ -23,6 +23,9 @@ class VersionList extends WidgetBase
         $this->alias = $alias;
 
         parent::__construct($controller, []);
+
+        $this->config->sort = $this->getSession('sort', 'asc');
+
         $this->bindToController();
     }
 
@@ -60,6 +63,15 @@ class VersionList extends WidgetBase
         return $this->updateList();
     }
 
+    public function onSort()
+    {
+        $this->config->sort = request()->sort;
+
+        $this->putSession('sort', $this->config->sort);
+
+        return ['#'.$this->getId('body') => $this->makePartial('widget-contents', $this->getRenderData())];
+    }
+
     /*
      * Methods for the internal use
      */
@@ -95,6 +107,10 @@ class VersionList extends WidgetBase
             }
 
             $items = $result;
+        }
+
+        if($this->getConfig('sort', 'asc') == 'desc') {
+            $items = array_reverse($items, false);
         }
 
         $versionManager = VersionManager::instance();

--- a/widgets/VersionList.php
+++ b/widgets/VersionList.php
@@ -65,7 +65,7 @@ class VersionList extends WidgetBase
 
     public function onSort()
     {
-        $this->config->sort = request()->sort;
+        $this->config->sort = Input::input('sort');
 
         $this->putSession('sort', $this->config->sort);
 
@@ -109,7 +109,7 @@ class VersionList extends WidgetBase
             $items = $result;
         }
 
-        if($this->getConfig('sort', 'asc') == 'desc') {
+        if ($this->getConfig('sort', 'asc') == 'desc') {
             $items = array_reverse($items, false);
         }
 

--- a/widgets/VersionList.php
+++ b/widgets/VersionList.php
@@ -69,7 +69,7 @@ class VersionList extends WidgetBase
 
         $this->putSession('sort', $this->config->sort);
 
-        return ['#'.$this->getId('body') => $this->makePartial('widget-contents', $this->getRenderData())];
+        return ['#' . $this->getId('body') => $this->makePartial('widget-contents', $this->getRenderData())];
     }
 
     /*

--- a/widgets/VersionList.php
+++ b/widgets/VersionList.php
@@ -109,7 +109,7 @@ class VersionList extends WidgetBase
             $items = $result;
         }
 
-        if ($this->getConfig('sort', 'asc') == 'desc') {
+        if ($this->getConfig('sort', 'asc') === 'desc') {
             $items = array_reverse($items, false);
         }
 

--- a/widgets/versionlist/partials/_sort.htm
+++ b/widgets/versionlist/partials/_sort.htm
@@ -1,8 +1,11 @@
-<div class="pull-right">
-    <?php if($this->getConfig('sort', 'asc') === 'asc'): ?>
-    <a href="javascript:;" data-request="<?= $this->getEventHandler('onSort') ?>" data-request-data="sort: 'desc'" class="white oc-icon-sort-numeric-desc" title="<?= e(trans('rainlab.builder::lang.version.sort_descending')) ?>"></a>
-    <?php else: ?>
-    <a href="javascript:;" data-request="<?= $this->getEventHandler('onSort') ?>" data-request-data="sort: 'asc'" class="white oc-icon-sort-numeric-asc"
-       title="<?= e(trans('rainlab.builder::lang.version.sort_ascending')) ?>"></a>
-    <?php endif; ?>
-</div>
+<?php if ($this->getConfig('sort', 'asc') === 'asc'): ?>
+    <button data-request="<?= $this->getEventHandler('onSort') ?>"
+            data-request-data="sort: 'desc'"
+            class="btn btn-default empty last oc-icon-sort-numeric-desc"
+            title="<?= e(trans('rainlab.builder::lang.version.sort_descending')) ?>"></button>
+<?php else: ?>
+    <button data-request="<?= $this->getEventHandler('onSort') ?>"
+            data-request-data="sort: 'asc'"
+            class="btn btn-default empty last oc-icon-sort-numeric-asc"
+            title="<?= e(trans('rainlab.builder::lang.version.sort_ascending')) ?>"></button>
+<?php endif; ?>

--- a/widgets/versionlist/partials/_sort.htm
+++ b/widgets/versionlist/partials/_sort.htm
@@ -1,11 +1,11 @@
 <?php if ($this->getConfig('sort', 'asc') === 'asc'): ?>
     <button data-request="<?= $this->getEventHandler('onSort') ?>"
-            data-request-data="sort: 'desc'"
-            class="btn btn-default empty last oc-icon-sort-numeric-desc"
-            title="<?= e(trans('rainlab.builder::lang.version.sort_descending')) ?>"></button>
+    data-request-data="sort: 'desc'"
+    class="btn btn-default empty last oc-icon-sort-numeric-desc"
+    title="<?= e(trans('rainlab.builder::lang.version.sort_descending')) ?>"></button>
 <?php else: ?>
     <button data-request="<?= $this->getEventHandler('onSort') ?>"
-            data-request-data="sort: 'asc'"
-            class="btn btn-default empty last oc-icon-sort-numeric-asc"
-            title="<?= e(trans('rainlab.builder::lang.version.sort_ascending')) ?>"></button>
+    data-request-data="sort: 'asc'"
+    class="btn btn-default empty last oc-icon-sort-numeric-asc"
+    title="<?= e(trans('rainlab.builder::lang.version.sort_ascending')) ?>"></button>
 <?php endif; ?>

--- a/widgets/versionlist/partials/_sort.htm
+++ b/widgets/versionlist/partials/_sort.htm
@@ -1,0 +1,8 @@
+<div class="pull-right">
+    <?php if($this->getConfig('sort', 'asc') === 'asc'): ?>
+    <a href="javascript:;" data-request="<?= $this->getEventHandler('onSort') ?>" data-request-data="sort: 'desc'" class="white oc-icon-sort-numeric-desc" title="<?= e(trans('rainlab.builder::lang.version.sort_descending')) ?>"></a>
+    <?php else: ?>
+    <a href="javascript:;" data-request="<?= $this->getEventHandler('onSort') ?>" data-request-data="sort: 'asc'" class="white oc-icon-sort-numeric-asc"
+       title="<?= e(trans('rainlab.builder::lang.version.sort_ascending')) ?>"></a>
+    <?php endif; ?>
+</div>

--- a/widgets/versionlist/partials/_toolbar.htm
+++ b/widgets/versionlist/partials/_toolbar.htm
@@ -2,7 +2,7 @@
     <div class="control-toolbar toolbar-padded">
         <div class="toolbar-item" data-calculate-width>
             <div class="btn-group">
-                <div class="dropdown last">
+                <div class="dropdown">
                     <button type="button" class="btn btn-default oc-icon-plus"
                         data-toggle="dropdown"
                         ><?= e(trans('rainlab.builder::lang.common.add')) ?></button>
@@ -11,10 +11,11 @@
                         <li role="presentation"><a role="menuitem" tabindex="-1" href="javascript:;" data-builder-command="version:cmdCreateVersion" data-version-type="custom" class="oc-icon-repeat"><?= e(trans('rainlab.builder::lang.version.custom')) ?></a></li>
 
                         <li role="presentation"><a role="menuitem" tabindex="-1" href="javascript:;" data-builder-command="version:cmdCreateVersion" data-version-type="migration" class="oc-icon-table"><?= e(trans('rainlab.builder::lang.version.migration')) ?></a></li>
-                        
+
                         <li role="presentation"><a role="menuitem" tabindex="-1" href="javascript:;" data-builder-command="version:cmdCreateVersion" data-version-type="seeder" class="oc-icon-th"><?= e(trans('rainlab.builder::lang.version.seeder')) ?></a></li>
                     </ul>
                 </div>
+                <?= $this->makePartial('sort'); ?>
             </div>
         </div>
         <div class="relative toolbar-item loading-indicator-container size-input-text">

--- a/widgets/versionlist/partials/_widget-contents.htm
+++ b/widgets/versionlist/partials/_widget-contents.htm
@@ -2,7 +2,6 @@
     <div class="sidepanel-content-header">
         <?php if ($pluginVector): ?>
             <span data-localization-key="<?= e($pluginVector->getPluginName()) ?>" data-plugin="<?= e($pluginVector->pluginCodeObj->toCode()) ?>"><?= e(trans($pluginVector->getPluginName())) ?></span>
-            <?= $this->makePartial('sort'); ?>
         <?php else: ?>
             <?= e(trans('rainlab.builder::lang.common.plugin_not_selected')) ?>
         <?php endif ?>

--- a/widgets/versionlist/partials/_widget-contents.htm
+++ b/widgets/versionlist/partials/_widget-contents.htm
@@ -2,6 +2,7 @@
     <div class="sidepanel-content-header">
         <?php if ($pluginVector): ?>
             <span data-localization-key="<?= e($pluginVector->getPluginName()) ?>" data-plugin="<?= e($pluginVector->pluginCodeObj->toCode()) ?>"><?= e(trans($pluginVector->getPluginName())) ?></span>
+            <?=$this->makePartial('sort'); ?>
         <?php else: ?>
             <?= e(trans('rainlab.builder::lang.common.plugin_not_selected')) ?>
         <?php endif ?>

--- a/widgets/versionlist/partials/_widget-contents.htm
+++ b/widgets/versionlist/partials/_widget-contents.htm
@@ -2,7 +2,7 @@
     <div class="sidepanel-content-header">
         <?php if ($pluginVector): ?>
             <span data-localization-key="<?= e($pluginVector->getPluginName()) ?>" data-plugin="<?= e($pluginVector->pluginCodeObj->toCode()) ?>"><?= e(trans($pluginVector->getPluginName())) ?></span>
-            <?=$this->makePartial('sort'); ?>
+            <?= $this->makePartial('sort'); ?>
         <?php else: ?>
             <?= e(trans('rainlab.builder::lang.common.plugin_not_selected')) ?>
         <?php endif ?>


### PR DESCRIPTION
While working on a big private plugin, I quite often go into the versions list of builder to create new manually migrations. After I edit those in an external editor, I have to re-open it in Builder to get new code before applying. When you have hundreds of versions, it's quite time consuming to scroll to the bottom every time you refresh. Example:
![Oct-17-2019 15-33-09](https://user-images.githubusercontent.com/271155/67009070-7f998f00-f0f3-11e9-8286-6e4b0c048932.gif)

This could be easily fixed by adding a new button on version list to reverse the order. This is my PR esentially:

-  Order versions ascending or descening
- Order is saved in session

After my changes:
![Oct-17-2019 15-35-34](https://user-images.githubusercontent.com/271155/67009216-cc7d6580-f0f3-11e9-8c49-64e23ae0da02.gif)

Changes are welcomed before merging.