### PR TITLE
Added "add database columns" to form builder

### DIFF
--- a/assets/js/builder.index.entity.modelform.js
+++ b/assets/js/builder.index.entity.modelform.js
@@ -63,7 +63,7 @@
         )
     }
 
-    ModelForm.prototype.cmdAddDatabaseColumns = function (ev) {
+    ModelForm.prototype.cmdAddFieldsFromDatabase = function (ev) {
         var $target = $(ev.currentTarget)
 
         // Always use the first placeholder to add controls

--- a/assets/js/builder.index.entity.modelform.js
+++ b/assets/js/builder.index.entity.modelform.js
@@ -83,13 +83,15 @@
         // addControlToPlaceholder requires a proper reflow of the whole form layout before
         // a new field can be added. This addField helper function makes sure that all
         // Promises are run in sequence to achieve this.
-        function addField (column) {
+        function addField (field) {
             return function () {
                 var defer = $.Deferred()
                 $.oc.builder.formbuilder.controller.addControlToPlaceholder(
                     $placeholder,
-                    column.type,
-                    column.label ? column.label : column.column
+                    field.type,
+                    field.label ? field.label : field.column,
+                    false,
+                    field.column
                 ).complete(function () {
                     defer.resolve()
                 })
@@ -99,8 +101,8 @@
 
         /// Add all fields in sequence.
         var allFields = $.when({})
-        $.each(fields, function (index, column) {
-            allFields = allFields.then(addField(column))
+        $.each(fields, function (index, field) {
+            allFields = allFields.then(addField(field))
         });
 
         // Once everything is done, hide the load indicator.

--- a/assets/js/builder.index.entity.modelform.js
+++ b/assets/js/builder.index.entity.modelform.js
@@ -107,35 +107,6 @@
         $.when(allFields).always($.oc.builder.indexController.hideStripeIndicatorProxy)
     }
 
-    ModelForm.prototype.databaseColumnsLoaded = function (data) {
-        if (!$.isArray(data.responseData.columns)) {
-            alert('Invalid server response')
-        }
-
-        var $masterTabPane = this.getMasterTabsActivePane(),
-            $form = $masterTabPane.find('form'),
-            existingColumns = this.getColumnNames($form),
-            columnsAdded = false
-
-        for (var i in data.responseData.columns) {
-            var column = data.responseData.columns[i],
-                type = this.mapType(column.type)
-
-            if ($.inArray(column.name, existingColumns) !== - 1) {
-                continue
-            }
-
-            this.addColumn($form, column.name, type)
-            columnsAdded = true
-        }
-
-        if (!columnsAdded) {
-            alert($form.attr('data-lang-all-database-columns-exist'))
-        } else {
-            $form.trigger('change')
-        }
-    }
-
     ModelForm.prototype.cmdOpenForm = function(ev) {
         var form = $(ev.currentTarget).data('form'),
             model = $(ev.currentTarget).data('modelClass')

--- a/behaviors/IndexModelFormOperations.php
+++ b/behaviors/IndexModelFormOperations.php
@@ -129,19 +129,19 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
         ];
     }
 
-    public function onModelShowAddDatabaseColumnsPopup()
+    public function onModelShowAddFieldsFromDatabasePopup()
     {
         $columns = ModelModel::getModelColumnsAndTypes($this->getPluginCode(), Input::get('model_class'));
-        $config  = $this->makeConfig($this->getAddDatabaseColumnsDataTableConfig());
+        $config = $this->makeConfig($this->getAddFieldsFromDatabaseDataTableConfig());
 
-        $field        = new FormField('add_database_columns', 'add_database_columns');
-        $field->value = $this->getAddDatabaseColumnsDataTableValue($columns);
+        $field = new FormField('add_fields_from_database', 'add_fields_from_database');
+        $field->value = $this->getAddFieldsFromDatabaseDataTableValue($columns);
 
-        $datatable        = new DataTable($this->controller, $field, $config);
-        $datatable->alias = 'add_database_columns_datatable';
+        $datatable = new DataTable($this->controller, $field, $config);
+        $datatable->alias = 'add_fields_from_database_datatable';
         $datatable->bindToController();
 
-        return $this->makePartial('add-database-columns-popup-form', [
+        return $this->makePartial('add-fields-from-database-popup-form', [
             'datatable'  => $datatable,
             'pluginCode' => $this->getPluginCode()->toCode(),
         ]);
@@ -206,11 +206,11 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
 
     /**
      * Returns the configuration for the DataTable widget that
-     * is used in the "add database columns" popup.
+     * is used in the "add fields from database" popup.
      *
      * @return array
      */
-    protected function getAddDatabaseColumnsDataTableConfig()
+    protected function getAddFieldsFromDatabaseDataTableConfig()
     {
         // Get all registered controls and build an array that uses the control types as key and value for each entry.
         $controls   = ControlLibrary::instance()->listControls();
@@ -249,7 +249,7 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
      *
      * @return array
      */
-    protected function getAddDatabaseColumnsDataTableValue(array $columns)
+    protected function getAddFieldsFromDatabaseDataTableValue(array $columns)
     {
         // Map database column types to widget types.
         $typeMap = [

--- a/behaviors/IndexModelFormOperations.php
+++ b/behaviors/IndexModelFormOperations.php
@@ -5,7 +5,9 @@ use RainLab\Builder\Classes\ModelFormModel;
 use RainLab\Builder\Classes\PluginCode;
 use RainLab\Builder\FormWidgets\FormBuilder;
 use RainLab\Builder\Classes\ModelModel;
+use RainLab\Builder\Classes\ControlLibrary;
 use Backend\Classes\FormField;
+use Backend\FormWidgets\DataTable;
 use ApplicationException;
 use Exception;
 use Request;
@@ -127,6 +129,24 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
         ];
     }
 
+    public function onModelShowAddDatabaseColumnsPopup()
+    {
+        $columns = ModelModel::getModelColumnsAndTypes($this->getPluginCode(), Input::get('model_class'));
+        $config  = $this->makeConfig($this->getAddDatabaseColumnsDataTableConfig());
+
+        $field        = new FormField('add_database_columns', 'add_database_columns');
+        $field->value = $this->getAddDatabaseColumnsDataTableValue($columns);
+
+        $datatable        = new DataTable($this->controller, $field, $config);
+        $datatable->alias = 'add_database_columns_datatable';
+        $datatable->bindToController();
+
+        return $this->makePartial('add-database-columns-popup-form', [
+            'datatable'  => $datatable,
+            'pluginCode' => $this->getPluginCode()->toCode(),
+        ]);
+    }
+
     protected function loadOrCreateFormFromPost()
     {
         $pluginCode = Request::input('plugin_code');
@@ -182,5 +202,79 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
             'pluginCode' => $pluginCode,
             'modelClass' => $fullClassName
         ];
+    }
+
+    /**
+     * Returns the configuration for the DataTable widget that
+     * is used in the "add database columns" popup.
+     *
+     * @return array
+     */
+    protected function getAddDatabaseColumnsDataTableConfig()
+    {
+        // Get all registered controls and build an array that uses the control types as key and value for each entry.
+        $controls   = ControlLibrary::instance()->listControls();
+        $fieldTypes = array_merge(array_keys($controls['Standard']), array_keys($controls['Widgets']));
+        $options    = array_combine($fieldTypes, $fieldTypes);
+
+        return [
+            'toolbar' => false,
+            'columns' => [
+                'add'    => [
+                    'title' => 'rainlab.builder::lang.common.add',
+                    'type'  => 'checkbox',
+                    'width' => '50px',
+                ],
+                'column' => [
+                    'title'    => 'rainlab.builder::lang.database.column_name_name',
+                    'readOnly' => true,
+                ],
+                'label'  => [
+                    'title' => 'rainlab.builder::lang.list.column_name_label',
+                ],
+                'type'   => [
+                    'title'   => 'rainlab.builder::lang.form.control_widget_type',
+                    'type'    => 'dropdown',
+                    'options' => $options,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Returns the initial value for the DataTable widget that
+     * is used in the "add database columns" popup.
+     *
+     * @param array $columns
+     *
+     * @return array
+     */
+    protected function getAddDatabaseColumnsDataTableValue(array $columns)
+    {
+        // Map database column types to widget types.
+        $typeMap = [
+            'string'       => 'text',
+            'integer'      => 'number',
+            'text'         => 'textarea',
+            'timestamp'    => 'datepicker',
+            'smallInteger' => 'number',
+            'bigInteger'   => 'number',
+            'date'         => 'datepicker',
+            'time'         => 'datepicker',
+            'dateTime'     => 'datepicker',
+            'binary'       => 'checkbox',
+            'boolean'      => 'checkbox',
+            'decimal'      => 'number',
+            'double'       => 'number',
+        ];
+
+        return array_map(function ($column) use ($typeMap) {
+            return [
+                'column' => $column['name'],
+                'label'  => ucfirst($column['name']),
+                'type'   => $typeMap[$column['type']] ?? $column['type'],
+                'add'    => false,
+            ];
+        }, $columns);
     }
 }

--- a/behaviors/IndexModelFormOperations.php
+++ b/behaviors/IndexModelFormOperations.php
@@ -271,7 +271,7 @@ class IndexModelFormOperations extends IndexOperationsBehaviorBase
         return array_map(function ($column) use ($typeMap) {
             return [
                 'column' => $column['name'],
-                'label'  => ucfirst($column['name']),
+                'label'  => str_replace('_', ' ', ucfirst($column['name'])),
                 'type'   => $typeMap[$column['type']] ?? $column['type'],
                 'add'    => false,
             ];

--- a/behaviors/indexmodelformoperations/partials/_add-database-columns-popup-form.htm
+++ b/behaviors/indexmodelformoperations/partials/_add-database-columns-popup-form.htm
@@ -1,0 +1,28 @@
+<?= Form::open([
+    'data-builder-command'=>'modelForm:cmdAddDatabaseColumns'
+]) ?>
+
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="popup">&times;</button>
+        <h4 class="modal-title"><?= e(trans('rainlab.builder::lang.list.btn_add_database_columns')) ?></h4>
+    </div>
+
+    <div class="modal-body">
+        <?= $datatable->render(); ?>
+    </div>
+    <div class="modal-footer">
+        <button
+            type="submit"
+            class="btn btn-primary">
+            <?= e(trans('backend::lang.form.apply')) ?>
+        </button>
+        <button
+            type="button"
+            class="btn btn-default"
+            data-dismiss="popup">
+            <?= e(trans('backend::lang.form.cancel')) ?>
+        </button>
+
+        <input type="hidden" name="plugin_code" value="<?= e($pluginCode) ?>">
+    </div>
+<?= Form::close() ?>

--- a/behaviors/indexmodelformoperations/partials/_add-fields-from-database-popup-form.htm
+++ b/behaviors/indexmodelformoperations/partials/_add-fields-from-database-popup-form.htm
@@ -1,10 +1,10 @@
 <?= Form::open([
-    'data-builder-command'=>'modelForm:cmdAddDatabaseColumns'
+    'data-builder-command'=>'modelForm:cmdAddFieldsFromDatabase'
 ]) ?>
 
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="popup">&times;</button>
-        <h4 class="modal-title"><?= e(trans('rainlab.builder::lang.list.btn_add_database_columns')) ?></h4>
+        <h4 class="modal-title"><?= e(trans('rainlab.builder::lang.form.btn_add_fields_from_database')) ?></h4>
     </div>
 
     <div class="modal-body">

--- a/behaviors/indexmodelformoperations/partials/_toolbar.htm
+++ b/behaviors/indexmodelformoperations/partials/_toolbar.htm
@@ -8,6 +8,16 @@
         <?= e(trans('backend::lang.form.save')) ?>
     </a>
 
+    <a
+        href="javascript:;"
+        class="btn btn-primary oc-icon-magic"
+        data-control="popup"
+        data-handler="onModelShowAddDatabaseColumnsPopup"
+        data-stripe-load-indicator
+    >
+        <?= e(trans('rainlab.builder::lang.list.btn_add_database_columns')) ?>
+    </a>
+
     <button
         type="button"
         class="btn btn-default empty oc-icon-trash-o <?php if (!strlen($fileName)): ?>hide<?php endif ?>"

--- a/behaviors/indexmodelformoperations/partials/_toolbar.htm
+++ b/behaviors/indexmodelformoperations/partials/_toolbar.htm
@@ -12,10 +12,10 @@
         href="javascript:;"
         class="btn btn-primary oc-icon-magic"
         data-control="popup"
-        data-handler="onModelShowAddDatabaseColumnsPopup"
+        data-handler="onModelShowAddFieldsFromDatabasePopup"
         data-stripe-load-indicator
     >
-        <?= e(trans('rainlab.builder::lang.list.btn_add_database_columns')) ?>
+        <?= e(trans('rainlab.builder::lang.form.btn_add_fields_from_database')) ?>
     </a>
 
     <button

--- a/formwidgets/formbuilder/assets/js/formbuilder.js
+++ b/formwidgets/formbuilder/assets/js/formbuilder.js
@@ -397,7 +397,7 @@
         return fieldName
     }
 
-    FormBuilder.prototype.addControlToPlaceholder = function(placeholder, controlType, controlName, noNewPlaceholder) {
+    FormBuilder.prototype.addControlToPlaceholder = function(placeholder, controlType, controlName, noNewPlaceholder, fieldName) {
         // Duplicate the placeholder and place it after
         // the existing one
         if (!noNewPlaceholder) {
@@ -420,7 +420,9 @@
         placeholder.innerHTML = ''
         placeholder.removeAttribute('data-builder-placeholder')
 
-        var fieldName = this.generateFieldName(controlType, placeholder)
+        if (!fieldName) {
+            fieldName = this.generateFieldName(controlType, placeholder)
+        }
 
         // Send request to the server to load the
         // control markup, Inspector data schema, inspector title, etc.

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -106,6 +106,7 @@ return [
         'saved' => 'Form saved',
         'confirm_delete' => 'Delete the form?',
         'tab_new_form' => 'New form',
+        'btn_add_fields_from_database' => 'Add fields from database',
         'property_label_title' => 'Label',
         'property_label_required' => 'Please specify the control label.',
         'property_span_title' => 'Span',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -346,6 +346,7 @@ return [
         'control_mediafinder_description' => 'Field for selecting an item from the Media Manager library',
         'control_relation' => 'Relation',
         'control_relation_description' => 'Displays either a dropdown or checkbox list for selecting a related record',
+        'control_widget_type' => 'Widget Type',
         'error_file_name_required' => 'Please enter the form file name.',
         'error_file_name_invalid' => 'The file name can contain only Latin letters, digits, underscores, dots and hashes.',
         'span_left' => 'Left',


### PR DESCRIPTION
This PR adds the "add database columns" feature to the form builder component. 

Let me know what you think!

![magic](https://user-images.githubusercontent.com/8600029/70316765-a5eac980-181c-11ea-8c53-13bc4cf9e27a.gif)

I also stumbled upon a bug where the datatable dropdown does not seem to work correctly when loaded in a popup. A fix is available, I'll work on a proper PR with a proof of the bug later today.

**Edit:** PR for this bugfix is here: https://github.com/octobercms/october/pull/4807

Just keep in mind to apply this fix to your installation if you are testing this PR:
https://github.com/OFFLINE-GmbH/october/commit/6ec2a85becc6f0a764013568674bde95fc19fe64