### PR TITLE
Add scroll to model list table.

### DIFF
--- a/assets/css/builder.css
+++ b/assets/css/builder.css
@@ -1105,22 +1105,26 @@ form.hide-secondary-tabs div.control-tabs.secondary-tabs ul.nav.nav-tabs {
 .form-group.size-three-quarter {
   width: 73.5%;
 }
-form[data-entity=database] div.field-datatable {
+form[data-entity=database] div.field-datatable,
+form[data-entity=models] div.field-datatable {
   position: absolute;
   width: 100%;
   height: 100%;
 }
-form[data-entity=database] div.field-datatable div[data-control=table] {
+form[data-entity=database] div.field-datatable div[data-control=table],
+form[data-entity=models] div.field-datatable div[data-control=table] {
   position: absolute;
   width: 100%;
   height: 100%;
 }
-form[data-entity=database] div.field-datatable div[data-control=table] div.table-container {
+form[data-entity=database] div.field-datatable div[data-control=table] div.table-container,
+form[data-entity=models] div.field-datatable div[data-control=table] div.table-container {
   position: absolute;
   width: 100%;
   height: 100%;
 }
-form[data-entity=database] div.field-datatable div[data-control=table] div.table-container div.control-scrollbar {
+form[data-entity=database] div.field-datatable div[data-control=table] div.table-container div.control-scrollbar,
+form[data-entity=models] div.field-datatable div[data-control=table] div.table-container div.control-scrollbar {
   top: 70px;
   bottom: 0;
   position: absolute;

--- a/assets/less/builder.less
+++ b/assets/less/builder.less
@@ -84,7 +84,8 @@ form.hide-secondary-tabs {
 
 // Full height database columns table
 
-form[data-entity=database] {
+form[data-entity=database],
+form[data-entity=models] {
     div.field-datatable {
         position: absolute;
         width: 100%;

--- a/classes/modellistmodel/fields.yaml
+++ b/classes/modellistmodel/fields.yaml
@@ -25,6 +25,8 @@ tabs:
             type: datatable
             btnAddRowLabel: rainlab.builder::lang.list.btn_add_column
             btnDeleteRowLabel: rainlab.builder::lang.list.btn_delete_column
+            height: 100
+            dynamicHeight: true
             columns:
                 field: 
                     title: rainlab.builder::lang.list.column_dbfield_label


### PR DESCRIPTION
Related issues: https://github.com/rainlab/builder-plugin/issues/149

Add scrolling to the model list table as well as the database table.
Reference: https://github.com/rainlab/builder-plugin/commit/f0716d8fd7dd473cbe7d3e539728587ba604f21f

Required to not hide the toolbar when there are many items.
The table generates scrolling only when a height is specified.
Reference: https://github.com/octobercms/october/blob/master/modules/backend/widgets/table/assets/js/table.js#L225

![Toolbar is hidden when there are many items](https://user-images.githubusercontent.com/37584143/76960780-7c832300-695f-11ea-9783-392983b7152b.png)
