### PR TITLE
"Add ID Column" button icon

### DIFF
--- a/assets/js/build-min.js
+++ b/assets/js/build-min.js
@@ -137,7 +137,7 @@ if(column=='allow_null'&&value){updatedRow.primary_key=0}
 if(column=='primary_key'&&!value){updatedRow.auto_increment=0}
 $target.table('setRowValues',rowIndex,updatedRow)}
 DatabaseTable.prototype.onTableLoaded=function(){$(document).trigger('render')
-var $masterTabPane=this.getMasterTabsActivePane(),$form=$masterTabPane.find('form'),$toolbar=$masterTabPane.find('div[data-control=table] div.toolbar'),$addIdButton=$('<a class="btn oc-icon-id-card-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),$addTimestampsButton=$('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddTimestamps"></a>'),$addSoftDeleteButton=$('<a class="btn oc-icon-refresh builder-custom-table-button" data-builder-command="databaseTable:cmdAddSoftDelete"></a>')
+var $masterTabPane=this.getMasterTabsActivePane(),$form=$masterTabPane.find('form'),$toolbar=$masterTabPane.find('div[data-control=table] div.toolbar'),$addIdButton=$('<a class="btn oc-icon-hashtag builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),$addTimestampsButton=$('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddTimestamps"></a>'),$addSoftDeleteButton=$('<a class="btn oc-icon-refresh builder-custom-table-button" data-builder-command="databaseTable:cmdAddSoftDelete"></a>')
 $addIdButton.text($form.attr('data-lang-add-id'));$toolbar.append($addIdButton)
 $addTimestampsButton.text($form.attr('data-lang-add-timestamps'));$toolbar.append($addTimestampsButton)
 $addSoftDeleteButton.text($form.attr('data-lang-add-soft-delete'));$toolbar.append($addSoftDeleteButton)}

--- a/assets/js/build-min.js
+++ b/assets/js/build-min.js
@@ -137,7 +137,7 @@ if(column=='allow_null'&&value){updatedRow.primary_key=0}
 if(column=='primary_key'&&!value){updatedRow.auto_increment=0}
 $target.table('setRowValues',rowIndex,updatedRow)}
 DatabaseTable.prototype.onTableLoaded=function(){$(document).trigger('render')
-var $masterTabPane=this.getMasterTabsActivePane(),$form=$masterTabPane.find('form'),$toolbar=$masterTabPane.find('div[data-control=table] div.toolbar'),$addIdButton=$('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),$addTimestampsButton=$('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddTimestamps"></a>'),$addSoftDeleteButton=$('<a class="btn oc-icon-refresh builder-custom-table-button" data-builder-command="databaseTable:cmdAddSoftDelete"></a>')
+var $masterTabPane=this.getMasterTabsActivePane(),$form=$masterTabPane.find('form'),$toolbar=$masterTabPane.find('div[data-control=table] div.toolbar'),$addIdButton=$('<a class="btn oc-icon-id-card-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),$addTimestampsButton=$('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddTimestamps"></a>'),$addSoftDeleteButton=$('<a class="btn oc-icon-refresh builder-custom-table-button" data-builder-command="databaseTable:cmdAddSoftDelete"></a>')
 $addIdButton.text($form.attr('data-lang-add-id'));$toolbar.append($addIdButton)
 $addTimestampsButton.text($form.attr('data-lang-add-timestamps'));$toolbar.append($addTimestampsButton)
 $addSoftDeleteButton.text($form.attr('data-lang-add-soft-delete'));$toolbar.append($addSoftDeleteButton)}

--- a/assets/js/builder.index.entity.databasetable.js
+++ b/assets/js/builder.index.entity.databasetable.js
@@ -168,7 +168,7 @@
         var $masterTabPane = this.getMasterTabsActivePane(),
             $form = $masterTabPane.find('form'),
             $toolbar = $masterTabPane.find('div[data-control=table] div.toolbar'),
-            $addIdButton = $('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),
+            $addIdButton = $('<a class="btn oc-icon-id-card-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),
             $addTimestampsButton = $('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddTimestamps"></a>'),
             $addSoftDeleteButton = $('<a class="btn oc-icon-refresh builder-custom-table-button" data-builder-command="databaseTable:cmdAddSoftDelete"></a>')
 

--- a/assets/js/builder.index.entity.databasetable.js
+++ b/assets/js/builder.index.entity.databasetable.js
@@ -168,7 +168,7 @@
         var $masterTabPane = this.getMasterTabsActivePane(),
             $form = $masterTabPane.find('form'),
             $toolbar = $masterTabPane.find('div[data-control=table] div.toolbar'),
-            $addIdButton = $('<a class="btn oc-icon-id-card-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),
+            $addIdButton = $('<a class="btn oc-icon-hashtag builder-custom-table-button" data-builder-command="databaseTable:cmdAddIdColumn"></a>'),
             $addTimestampsButton = $('<a class="btn oc-icon-clock-o builder-custom-table-button" data-builder-command="databaseTable:cmdAddTimestamps"></a>'),
             $addSoftDeleteButton = $('<a class="btn oc-icon-refresh builder-custom-table-button" data-builder-command="databaseTable:cmdAddSoftDelete"></a>')
 


### PR DESCRIPTION
I authored #293 last year to create the "Add ID Column" button in the migration editor. Only just noticed that it has a `clock` icon next to it!

I think it would suit the function better to have `id-card-o` icon instead:

![with id-card-o](https://user-images.githubusercontent.com/41773797/78077016-7b121b80-739f-11ea-82c4-78654af8528f.png)