### PR TITLE
Compatibility fixes and tweaks

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -153,5 +153,10 @@ class Plugin extends PluginBase
         CombineAssets::registerCallback(function ($combiner) {
             $combiner->registerBundle('$/rainlab/builder/assets/js/build.js');
         });
+
+        /**
+         * Add provider for "timestamp" type for MySQL and SQLite
+         */
+        $this->app->register(\MarkTopper\DoctrineDBALTimestampType\Laravel5ServiceProvider::class);
     }
 }

--- a/classes/DatabaseTableModel.php
+++ b/classes/DatabaseTableModel.php
@@ -297,10 +297,6 @@ class DatabaseTableModel extends BaseModel
             if (!strlen($column['default'])) {
                 continue;
             }
-            // Allow null value for all nullable columns
-            if (strtolower($column['default']) === 'null' && (bool) $column['allow_null'] === true) {
-                continue;
-            }
 
             $default = trim($column['default']);
 
@@ -387,15 +383,6 @@ class DatabaseTableModel extends BaseModel
                 'default' => $column->getDefault(),
                 'id' => $columnName,
             ];
-
-            // Format quoted "null" values with quotes
-            if ($column->getNotnull() === false) {
-                if ($item['default'] === null) {
-                    $item['default'] = 'null';
-                } elseif (strtolower($item['default']) === 'null') {
-                    $item['default'] = "'null'";
-                }
-            }
 
             $this->columns[] = $item;
         }

--- a/classes/DatabaseTableSchemaCreator.php
+++ b/classes/DatabaseTableSchemaCreator.php
@@ -58,17 +58,7 @@ class DatabaseTableSchemaCreator extends BaseModel
         // But converting empty strings to NULLs is required for the further
         // work with Doctrine types. As an option - empty strings could be specified
         // as '' in the editor UI (table column editor).
-        if ($result['notnull'] === false) {
-            if (strtolower($default) === 'null') {
-                $result['default'] = null;
-            } elseif (preg_match('/^[\'"]null[\'"]$/i', $default)) {
-                $result['default'] = 'null';
-            } else {
-                $result['default'] = $default === '' ? null : $default;
-            }
-        } else {
-            $result['default'] = $default === '' ? null : $default;
-        }
+        $result['default'] = $default === '' ? null : $default;
 
         return $result;
     }

--- a/classes/databasetablemodel/fields.yaml
+++ b/classes/databasetablemodel/fields.yaml
@@ -29,17 +29,19 @@ tabs:
             dynamicHeight: true
             columns:
                 name:
+                    width: 18%
                     title: rainlab.builder::lang.database.column_name_name
-                    validation: 
-                        required: 
+                    validation:
+                        required:
                             message: rainlab.builder::lang.database.column_name_required
                         regex:
                             pattern: ^[0-9_a-z]+$
                             message: rainlab.builder::lang.database.column_validation_title
                 type:
+                    width: 14%
                     title: rainlab.builder::lang.database.column_name_type
                     type: dropdown
-                    options: 
+                    options:
                         integer: Integer
                         smallInteger: Small Integer
                         bigInteger: Big Integer
@@ -53,25 +55,30 @@ tabs:
                         boolean: Boolean
                         decimal: Decimal
                         double: Double
-                    validation: 
-                        required: 
+                    validation:
+                        required:
                             message: rainlab.builder::lang.database.column_type_required
                 length:
+                    width: 8%
                     title: rainlab.builder::lang.database.column_name_length
                     validation:
                         regex:
                             pattern: (^[0-9]+$)|(^[0-9]+,[0-9]+$)
                             message: rainlab.builder::lang.database.column_validation_length
                 unsigned:
+                    width: 8%
                     title: rainlab.builder::lang.database.column_name_unsigned
                     type: checkbox
                 allow_null:
+                    width: 8%
                     title: rainlab.builder::lang.database.column_name_nullable
                     type: checkbox
                 auto_increment:
+                    width: 8%
                     title: rainlab.builder::lang.database.column_auto_increment
                     type: checkbox
                 primary_key:
+                    width: 8%
                     title: rainlab.builder::lang.database.column_auto_primary_key
                     type: checkbox
                     width: 50px

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "composer/installers": "~1.0"
+        "composer/installers": "~1.0",
+        "marktopper/doctrine-dbal-timestamp-type": "^1.0.2"
     },
     "require-dev": {
       "phpunit/phpunit": "~4.0"


### PR DESCRIPTION
This commit will fix https://github.com/rainlab/builder-plugin/issues/295 and https://github.com/rainlab/builder-plugin/issues/328.

Commit f1f0f4523d5d084779a18d481bfe3a615e4ff1f9 brought in changes that allowed null default values to be specified as `null` (without quotes) to be marked as nulled by default, with a quoted null default value to be a string value of `"null"`. It was reported by several people on Slack as well as #295 that this did not work. This rolls back the changes for null, while keeping the changes for the boolean default values. Doctrine, by default, will mark any column that is nullable as `null` by default, unless a specific default value is given.

This also brings in the https://github.com/marktopper/doctrine-dbal-timestamp-type library to provide support for timestamp columns.

Finally, some sensible widths were put in to columns of the database table datatable widget, to make it a bit more uniform.

As this is technically a breaking change, it will be released as a "critical" update.