### PR TITLE
Import missing ApplicationException class

### DIFF
--- a/classes/ModelModel.php
+++ b/classes/ModelModel.php
@@ -1,6 +1,7 @@
 <?php namespace RainLab\Builder\Classes;
 
 use DirectoryIterator;
+use ApplicationException;
 use SystemException;
 use Validator;
 use Lang;


### PR DESCRIPTION
When attempting to add database columns when the table does not exist, an ApplicationException is thrown but the class is not imported. This quick fix resolves the issue.