### PR TITLE
Fix method declaration of test

### DIFF
--- a/tests/unit/classes/ModelModelTest.php
+++ b/tests/unit/classes/ModelModelTest.php
@@ -5,7 +5,7 @@ use RainLab\Builder\Classes\PluginCode;
 
 class ModelModelTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         // Ensure cleanup for testGetModelFields
         @unlink(__DIR__.'/../../../models/MyMock.php');


### PR DESCRIPTION
Test fails because of outdated method declaration.

What is the minimum PHP requirements of this plugin btw?
And I wonder if we can update PHPUnit version, and maybe add a `.gitignore` file and ignoring the composer.lock file.